### PR TITLE
fix: manifest file has not been taken into account

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ this for the first time might require to run `direnv allow`. Shorthand
 commands, for example those mentioned in chapter "Running tests", can be
 enumerated using `just --help`.
 
+In order to test whether the package would be built correctly, you can
+run `python setup.py build` in the development shell to inspect whether
+`build/lib/parviraptor/` looks as expected.
+
 ## Installation
 
 Just add `'parviraptor'` to your `INSTALLED_APPS` Django setting as usual.

--- a/flake.nix
+++ b/flake.nix
@@ -18,6 +18,7 @@
                 ps.black
                 ps.flake8
                 ps.isort
+                ps.setuptools
             ]))
             just
           ];

--- a/parviraptor/__init__.py
+++ b/parviraptor/__init__.py
@@ -1,6 +1,6 @@
 import sys
 
-__version__ = "3.0.1"
+__version__ = "3.0.2"
 
 if sys.version_info < (3, 12):
     raise RuntimeError("parviraptor requires at least python 3.12")

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ setup(
     name="parviraptor",
     version=__version__,
     description="Django-based job queue",
+    include_package_data=True,
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",
     author="puzzleYOU GmbH",


### PR DESCRIPTION
## Summary by Sourcery

Enable inclusion of manifest files in package builds by updating setup configuration, bumping the version, and refreshing documentation and development tools

Bug Fixes:
- Add include_package_data=True in setup.py to ensure manifest files are packaged

Build:
- Include setuptools in flake.nix development environment

Documentation:
- Add README instructions for running and inspecting python setup.py build

Chores:
- Bump package version to 3.0.2