### PR TITLE
Handle cleanup old jobs

### DIFF
--- a/parviraptor/management/commands/clean_old_finished_jobs.py
+++ b/parviraptor/management/commands/clean_old_finished_jobs.py
@@ -1,9 +1,8 @@
 import logging
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from django.apps import apps
-from django.core.management.base import BaseCommand
-from django.utils import timezone
+from django.core.management.base import BaseCommand, CommandParser
 
 from parviraptor.models.abstract import AbstractJob
 from parviraptor.utils import enumerate_job_models, iter_chunks
@@ -14,7 +13,7 @@ logger = logging.getLogger(__name__)
 class Command(BaseCommand):
     help = "Cleans up obsolete finished jobs"
 
-    def add_arguments(self, parser):
+    def add_arguments(self, parser: CommandParser):
         parser.add_argument(
             "max_age_in_days",
             type=int,
@@ -45,7 +44,7 @@ class Command(BaseCommand):
         )
 
     def handle(self, max_age_in_days: int, **options):
-        relevant_job_models = (
+        relevant_job_models: list[type[AbstractJob]] = (
             enumerate_job_models()
             if options["all_queues"]
             else [_load_model_from_fully_qualified_name(options["queue"])]

--- a/parviraptor/models/abstract.py
+++ b/parviraptor/models/abstract.py
@@ -67,6 +67,14 @@ class AbstractJob(models.Model):
     BACKOFF_STEP_MINUTES = 2
     BACKOFF_STRATEGY = BackoffStrategy.EXPONENTIAL
 
+    MAX_AGE_FOR_PROCESSED_JOBS_IN_DAYS: int | None = 7
+    """
+    time in days to hold Jobs with status "PROCESSED" before they will be
+    deleted.
+    If the value is None, the deletion for this specific job is deactivated.
+    This variable can be overridden by its subclasses.
+    """
+
     @classmethod
     def get_dependent_fields(cls):
         if not hasattr(cls, "dependent_fields"):

--- a/tests/commands/test_clean_old_finished_jobs.py
+++ b/tests/commands/test_clean_old_finished_jobs.py
@@ -6,6 +6,7 @@ from django.core.management import call_command
 from django.test import TransactionTestCase
 from django.utils import timezone
 
+from parviraptor.models.abstract import AbstractJob
 from tests.models import DummyJob, DummyProductJob, IncrementCounterJob
 
 COMMAND_MODULE = "parviraptor.management.commands.clean_old_finished_jobs"
@@ -15,15 +16,12 @@ class CleanOldFinishedJobsTests(TransactionTestCase):
     def test_can_process_all_queues(self):
         jobs = []
 
-        def patched(Job, max_age_in_days):
-            self.assertEqual(1, max_age_in_days)
+        def patched(Job: type[AbstractJob], _):
+            self.assertEqual(7, Job.MAX_AGE_FOR_PROCESSED_JOBS_IN_DAYS)
             jobs.append(Job)
 
-        with patch(
-            COMMAND_MODULE + "._delete_old_finished_jobs",
-            patched,
-        ):
-            self._call_command("1", "--all-queues")
+        with patch(f"{COMMAND_MODULE}._delete_old_finished_jobs", patched):
+            self._call_command("--all-queues")
 
         self.assertCountEqual(
             [DummyJob, DummyProductJob, IncrementCounterJob], jobs
@@ -32,20 +30,19 @@ class CleanOldFinishedJobsTests(TransactionTestCase):
     def test_can_process_single_queue(self):
         jobs = []
 
-        def patched(Job, max_age_in_days):
-            self.assertEqual(1, max_age_in_days)
+        def patched(Job: type[AbstractJob], _):
+            self.assertEqual(7, Job.MAX_AGE_FOR_PROCESSED_JOBS_IN_DAYS)
             jobs.append(Job)
 
-        with patch(
-            COMMAND_MODULE + "._delete_old_finished_jobs",
-            patched,
-        ):
-            self._call_command("1", "--queue=tests.DummyJob")
+        with patch(f"{COMMAND_MODULE}._delete_old_finished_jobs", patched):
+            self._call_command("--queue=tests.DummyJob")
 
         self.assertEqual([DummyJob], jobs)
 
     def test_leaves_unfinished_old_jobs_untouched(self):
-        old_date = datetime.now(tz=timezone.utc) - timedelta(days=23)
+        old_date = datetime.now(tz=timezone.utc) - timedelta(
+            days=DummyJob.MAX_AGE_FOR_PROCESSED_JOBS_IN_DAYS
+        )
 
         DummyJob.objects.create(a=1, b=2, status="PROCESSED")
         DummyJob.objects.create(a=1, b=2, status="FAILED")
@@ -55,8 +52,8 @@ class CleanOldFinishedJobsTests(TransactionTestCase):
         DummyJob.objects.create(a=1, b=2, status="PROCESSED")
 
         self.assertEqual(5, DummyJob.objects.count())
-        self._call_command("1", "--queue=tests.DummyJob")
-        self.assertEqual(4, DummyJob.objects.count())
+        self._call_command("--queue=tests.DummyJob")
+        self.assertEqual(3, DummyJob.objects.count())
 
     def test_no_jobs_to_be_deleted(self):
         DummyJob.objects.create(a=1, b=2, status="PROCESSED")
@@ -66,11 +63,13 @@ class CleanOldFinishedJobsTests(TransactionTestCase):
         DummyJob.objects.create(a=1, b=2, status="PROCESSED")
 
         self.assertEqual(5, DummyJob.objects.count())
-        self._call_command("1", "--queue=tests.DummyJob")
+        self._call_command("--queue=tests.DummyJob")
         self.assertEqual(5, DummyJob.objects.count())
 
     def test_can_delete_all_old_finished_jobs(self):
-        old_date = datetime.now(tz=timezone.utc) - timedelta(days=23)
+        old_date = datetime.now(tz=timezone.utc) - timedelta(
+            days=DummyJob.MAX_AGE_FOR_PROCESSED_JOBS_IN_DAYS
+        )
 
         DummyJob.objects.create(a=1, b=2, status="PROCESSED")
         DummyJob.objects.create(a=1, b=2, status="PROCESSED")
@@ -80,8 +79,42 @@ class CleanOldFinishedJobsTests(TransactionTestCase):
         DummyJob.objects.create(a=1, b=2, status="PROCESSED")
 
         self.assertEqual(5, DummyJob.objects.count())
-        self._call_command("1", "--queue=tests.DummyJob")
+        self._call_command("--queue=tests.DummyJob")
         self.assertEqual(2, DummyJob.objects.count())
+
+    def test_chunked_deletion_removes_all_jobs(self):
+        old_date = datetime.now(tz=timezone.utc) - timedelta(days=23)
+
+        num_jobs = 2500
+        for i in range(num_jobs):
+            DummyJob.objects.create(a=1, b=2, status="PROCESSED")
+        DummyJob.objects.create(a=1, b=2, status="PENDING")
+        DummyJob.objects.create(a=1, b=2, status="FAILED")
+        DummyJob.objects.all().update(modification_date=old_date)
+
+        self.assertEqual(num_jobs + 2, DummyJob.objects.count())
+
+        self._call_command("--queue=tests.DummyJob")
+
+        remaining_jobs = DummyJob.objects.exclude(status="PROCESSED")
+        self.assertEqual(2, remaining_jobs.count())
+        self.assertEqual(2, DummyJob.objects.count())
+
+    def test_dry_run_prevents_deletion(self):
+        old_date = datetime.now(tz=timezone.utc) - timedelta(
+            days=DummyJob.MAX_AGE_FOR_PROCESSED_JOBS_IN_DAYS
+        )
+
+        DummyJob.objects.create(a=1, b=2, status="PROCESSED")
+        DummyJob.objects.create(a=1, b=2, status="PROCESSED")
+        DummyJob.objects.create(a=1, b=2, status="PROCESSED")
+        DummyJob.objects.all().update(modification_date=old_date)
+        DummyJob.objects.create(a=1, b=2, status="PROCESSED")
+        DummyJob.objects.create(a=1, b=2, status="PROCESSED")
+
+        self.assertEqual(5, DummyJob.objects.count())
+        self._call_command("--queue=tests.DummyJob", "--dry-run")
+        self.assertEqual(5, DummyJob.objects.count())
 
     def _call_command(self, *args):
         DEV_NULL = StringIO()


### PR DESCRIPTION
## Summary by Sourcery

Revamp the old jobs cleanup command to use per-model default ages, add a dry-run mode, simplify deletion logic, and update tests accordingly

New Features:
- Add a --dry-run option to preview job deletions without executing them

Enhancements:
- Switch to using a per-model MAX_JOB_AGE_IN_DAYS constant instead of a positional age argument
- Refactor the cleanup command to delegate to a _handle helper and store dry-run state in the command instance
- Simplify filtering to delete only processed jobs and remove the stop-on-first-failure logic
- Introduce PERFORM_JOB_CLEANUP and MAX_JOB_AGE_IN_DAYS attributes on AbstractJob for default cleanup settings

Tests:
- Update tests to drop the positional age argument, rely on MAX_JOB_AGE_IN_DAYS, and accommodate the dry-run behavior