### PR TITLE
Cleanup job index

### DIFF
--- a/parviraptor/__init__.py
+++ b/parviraptor/__init__.py
@@ -1,6 +1,6 @@
 import sys
 
-__version__ = "3.3.0"
+__version__ = "3.3.1"
 
 if sys.version_info < (3, 12):
     raise RuntimeError("parviraptor requires at least python 3.12")

--- a/parviraptor/management/commands/clean_old_finished_jobs.py
+++ b/parviraptor/management/commands/clean_old_finished_jobs.py
@@ -76,7 +76,7 @@ def _delete_in_chunks(Job: type[AbstractJob], jobs, dry_run: bool = False):
     remainder = 0 if pks_count % CHUNK_SIZE == 0 else 1
     chunk_count = full_chunks + remainder
 
-    logger.info(f"{Job.__name__}: Process {pks_count} jobs...")
+    logger.info(f"{Job.__name__}: Processing {pks_count} jobs...")
     for i, chunk in enumerate(iter_chunks(CHUNK_SIZE, pks), start=1):
         logger.info(f"{Job.__name__}: processing chunk {i}/{chunk_count}")
         if dry_run:

--- a/parviraptor/management/commands/clean_old_finished_jobs.py
+++ b/parviraptor/management/commands/clean_old_finished_jobs.py
@@ -76,6 +76,7 @@ def _delete_in_chunks(Job: type[AbstractJob], jobs, dry_run: bool = False):
     remainder = 0 if pks_count % CHUNK_SIZE == 0 else 1
     chunk_count = full_chunks + remainder
 
+    logger.info(f"{Job.__name__}: Process {pks_count} jobs...")
     for i, chunk in enumerate(iter_chunks(CHUNK_SIZE, pks), start=1):
         logger.info(f"{Job.__name__}: processing chunk {i}/{chunk_count}")
         if dry_run:

--- a/parviraptor/models/abstract.py
+++ b/parviraptor/models/abstract.py
@@ -279,6 +279,9 @@ class AbstractJob(models.Model):
 
     class Meta:
         abstract = True
+        indexes = [
+            models.Index(fields=["modification_date", "status"]),
+        ]
 
 
 class AbstractJobFactory:


### PR DESCRIPTION
## Summary by Sourcery

Add a composite index to the AbstractJob model, enhance cleanup command logging, and bump the package version to 3.3.1

Enhancements:
- Add a database index on modification_date and status fields in AbstractJob model
- Log the total number of jobs to process in clean_old_finished_jobs command

Build:
- Bump version to 3.3.1